### PR TITLE
docs: fix installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The aim of this starter is to provide a super bare-bones setup for Next.js with 
 
 ```bash
 # Create a new Next.js project using the starter
-bun create next-app@latest -e https://github.com/ixahmedxi/next-minimal-starter
+bunx create-next-app -e https://github.com/ixahmedxi/next-minimal-starter
 
 # Navigate into the project
 cd <project-name>


### PR DESCRIPTION
- close #1 

Fixed installation instruction in README. Based on Next.js Official Docs. [Link](https://nextjs.org/docs/app/api-reference/create-next-app)

(I love this starter template so much. Thank you for your efforts!)